### PR TITLE
[Release 1.12.3] Add support to build and release to S3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ core
 
 # Mac OS
 .DS_Store
+
+.idea

--- a/Dockerfile-builder
+++ b/Dockerfile-builder
@@ -1,0 +1,4 @@
+ARG REDHAT_UBI8_VERSION=8.6
+FROM redhat/ubi8:$REDHAT_UBI8_VERSION
+
+RUN yum -y makecache && yum install -y make gcc gcc-c++

--- a/Makefile
+++ b/Makefile
@@ -247,3 +247,7 @@ dist_in_docker: distclean
 		-w /workspace \
 		--entrypoint make \
 		 $(shell docker build -q -f Dockerfile-builder .)
+
+publish_to_s3:
+	version=$(shell grep '#define VER "' version.h | cut -d '"' -f2) && \
+	s3cmd put ./$(PROGRAM_NAME) "s3://artifacts.h2o.ai/deps/dai/$(PROGRAM_NAME)/$$version/"

--- a/Makefile
+++ b/Makefile
@@ -238,3 +238,12 @@ chrootpackage:
 	+./chroot_build.sh
 package:
 	+./generate_packages.sh
+
+dist_in_docker: distclean
+	docker run \
+		--rm -it \
+		-u `id -u`:`id -g` \
+		-v `pwd`:/workspace \
+		-w /workspace \
+		--entrypoint make \
+		 $(shell docker build -q -f Dockerfile-builder .)


### PR DESCRIPTION
To build inside a CentOS Docker container: `make dist_in_docker`
Then run `make publish_to_s3` to publish to AWS S3 bucket.